### PR TITLE
feat: add QuickFacts component for displaying key information about b…

### DIFF
--- a/src/app/brostoperationer/brostforstoring/Brostforstoring.tsx
+++ b/src/app/brostoperationer/brostforstoring/Brostforstoring.tsx
@@ -15,7 +15,15 @@ import { BgColors } from '@/app/types'
 
 import ImplantsInHand from '../../../../public/images/_N3A7297.jpg'
 import { useAccordionData } from './accordionData'
-
+import { QuickFacts } from '@/app/components/surfaces/QuickFacts'
+import {
+  Activity,
+  Banknote,
+  Calendar,
+  Clock,
+  Clock3,
+  Hospital
+} from 'lucide-react'
 
 const Brostforstoring = () => {
   const t = useTranslations('brostforstoring')
@@ -29,10 +37,9 @@ const Brostforstoring = () => {
         content={
           <Pillar>
             <H1 white>{t('title')}</H1>
-            <P white>{t.rich('background', {
-                strong: (chunks) => (
-                  <strong>{chunks}</strong>
-                )
+            <P white>
+              {t.rich('background', {
+                strong: (chunks) => <strong>{chunks}</strong>
               })}
             </P>
             <P white>{t('background2')}</P>
@@ -40,34 +47,50 @@ const Brostforstoring = () => {
         }
       />
 
+      <QuickFacts
+        title="Snabbfakta om bröstförstoring"
+        facts={[
+          { icon: Banknote, label: 'Pris', value: 'från 55 000 SEK' },
+          { icon: Clock, label: 'Operationstid', value: '1.5–2 timmar' },
+          { icon: Hospital, label: 'Anestesi', value: 'Narkos' },
+          { icon: Activity, label: 'Återhämtningstid', value: '2-4 veckor' },
+          {
+            icon: Calendar,
+            label: 'Klinikbesök',
+            value: 'Krävs för konsultation och uppföljning'
+          },
+          { icon: Clock3, label: 'Sjukskrivning', value: '2-3 veckor' }
+        ]}
+        ctaText="Boka konsultation"
+        ctaUrl="/booking/consultation"
+      />
+
       <SimpleCard
         bgColor={BgColors.White}
         bgPosition="left"
         content={
           <Pillar noPadding>
-              <Image
-                src={ImplantsInHand}
-                alt={t('altText.ImplantsInHand')}
-                className="max-h-svh object-cover object-center"
-              />      
+            <Image
+              src={ImplantsInHand}
+              alt={t('altText.ImplantsInHand')}
+              className="max-h-svh object-cover object-center"
+            />
 
             <SpaceContainer spaceTop noPadding>
               <Section>
-                  <H2>{t('implanttitle')}</H2>
-                  <P>{t.rich('implantbackground.text1', {
-                      strong: (chunks) => (
-                        <strong>{chunks}</strong>
-                      )
-                      })}
-                  </P>
-                  <P>{t.rich('implantbackground.text2', {
-                      strong: (chunks) => (
-                        <strong>{chunks}</strong>
-                      )
-                      })}
-                  </P>
+                <H2>{t('implanttitle')}</H2>
+                <P>
+                  {t.rich('implantbackground.text1', {
+                    strong: (chunks) => <strong>{chunks}</strong>
+                  })}
+                </P>
+                <P>
+                  {t.rich('implantbackground.text2', {
+                    strong: (chunks) => <strong>{chunks}</strong>
+                  })}
+                </P>
               </Section>
-            </SpaceContainer>          
+            </SpaceContainer>
             <SpaceContainer noPadding>
               <Section>
                 <H3>{'Vanliga frågor & svar om bröstförstoring'}</H3>
@@ -79,7 +102,7 @@ const Brostforstoring = () => {
                 </div>
               </Section>
             </SpaceContainer>
-          </Pillar>          
+          </Pillar>
         }
       />
       <SpaceContainer spaceVertically noPadding>
@@ -104,8 +127,14 @@ const Brostforstoring = () => {
       <SpaceContainer>
         <Pillar>
           <Section>
-            <H2>{'Hur går en bröstförstoring till? – En teknisk djupdykning'}</H2>
-            <P>{'På Dahliakliniken värdesätter vi trygghet, kunskap och transparens. Vi strävar alltid efter att ge dig som patient tydlig och saklig information om våra behandlingar och estetiska ingrepp. En vanlig fråga vi får är: Hur går en bröstförstoringsoperation till?'}</P>
+            <H2>
+              {'Hur går en bröstförstoring till? – En teknisk djupdykning'}
+            </H2>
+            <P>
+              {
+                'På Dahliakliniken värdesätter vi trygghet, kunskap och transparens. Vi strävar alltid efter att ge dig som patient tydlig och saklig information om våra behandlingar och estetiska ingrepp. En vanlig fråga vi får är: Hur går en bröstförstoringsoperation till?'
+              }
+            </P>
             <H3>{t('technique.heading1')}</H3>
             <P>{t('technique.text1')}</P>
             <Accordion size="h4" items={teknikAccordion} />
@@ -156,7 +185,7 @@ const Brostforstoring = () => {
         </Pillar>
       </SpaceContainer>
 
-{/*       <SpaceContainer spaceVertically noPadding>
+      {/*       <SpaceContainer spaceVertically noPadding>
         <SimpleCard
           bgColor={BgColors.Green}
           bgPosition="right"

--- a/src/app/brostoperationer/brostforstoring/Brostforstoring.tsx
+++ b/src/app/brostoperationer/brostforstoring/Brostforstoring.tsx
@@ -1,3 +1,11 @@
+import {
+  Activity,
+  Banknote,
+  Calendar,
+  Clock,
+  Clock3,
+  Hospital
+} from 'lucide-react'
 import Image from 'next/image'
 import { useTranslations } from 'next-intl'
 
@@ -5,6 +13,7 @@ import { Pillar } from '@/app/components/layout/Pillar'
 import { Section } from '@/app/components/layout/Section'
 import { SpaceContainer } from '@/app/components/layout/SpaceContainer'
 import { Accordion } from '@/app/components/surfaces/Accordion'
+import { QuickFacts } from '@/app/components/surfaces/QuickFacts'
 import { SimpleCard } from '@/app/components/surfaces/SimpleCard'
 import { A } from '@/app/components/typography/A'
 import { H1 } from '@/app/components/typography/H1'
@@ -15,15 +24,6 @@ import { BgColors } from '@/app/types'
 
 import ImplantsInHand from '../../../../public/images/_N3A7297.jpg'
 import { useAccordionData } from './accordionData'
-import { QuickFacts } from '@/app/components/surfaces/QuickFacts'
-import {
-  Activity,
-  Banknote,
-  Calendar,
-  Clock,
-  Clock3,
-  Hospital
-} from 'lucide-react'
 
 const Brostforstoring = () => {
   const t = useTranslations('brostforstoring')

--- a/src/app/brostoperationer/brostforstoring/Brostforstoring.tsx
+++ b/src/app/brostoperationer/brostforstoring/Brostforstoring.tsx
@@ -62,7 +62,7 @@ const Brostforstoring = () => {
           { icon: Clock3, label: 'Sjukskrivning', value: '2-3 veckor' }
         ]}
         ctaText="Boka konsultation"
-        ctaUrl="/booking/consultation"
+        ctaUrl="/boka"
       />
 
       <SimpleCard

--- a/src/app/components/surfaces/QuickFacts.tsx
+++ b/src/app/components/surfaces/QuickFacts.tsx
@@ -1,7 +1,8 @@
 import type { LucideIcon } from 'lucide-react'
 import type { ReactNode } from 'react'
-import { H2 } from '../typography/H2'
+
 import { A } from '../typography/A'
+import { H2 } from '../typography/H2'
 
 /**
  * Represents a single fact item in the QuickFacts component
@@ -81,7 +82,7 @@ export const QuickFacts = ({
                 aria-hidden="true"
               />
               <div className="flex flex-wrap items-baseline">
-                <dt className="mr-2">{fact.label}:</dt>
+                <dt className="mr-2">{`${fact.label}:`}</dt>
                 <dd className="font-light">
                   {typeof fact.value === 'string' ? fact.value : fact.value}
                 </dd>

--- a/src/app/components/surfaces/QuickFacts.tsx
+++ b/src/app/components/surfaces/QuickFacts.tsx
@@ -84,7 +84,7 @@ export const QuickFacts = ({
               <div className="flex flex-wrap items-baseline">
                 <dt className="mr-2">{`${fact.label}:`}</dt>
                 <dd className="font-light">
-                  {typeof fact.value === 'string' ? fact.value : fact.value}
+                  {fact.value}
                 </dd>
               </div>
             </div>

--- a/src/app/components/surfaces/QuickFacts.tsx
+++ b/src/app/components/surfaces/QuickFacts.tsx
@@ -1,0 +1,109 @@
+import type { LucideIcon } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { H2 } from '../typography/H2'
+import { A } from '../typography/A'
+
+/**
+ * Represents a single fact item in the QuickFacts component
+ * @property {LucideIcon} icon - The Lucide React icon to display next to the fact
+ * @property {string} label - The label text for the fact (e.g., "Price", "Duration")
+ * @property {string | ReactNode} value - The value of the fact, can be a string or a React node for complex content
+ */
+export type FactItem = {
+  icon: LucideIcon
+  label: string
+  value: string | ReactNode
+}
+
+/**
+ * Props for the QuickFacts component
+ * @property {string} title - The title of the quick facts section
+ * @property {FactItem[]} facts - An array of fact items to display
+ * @property {string} [ctaText] - Optional text for the call-to-action button
+ * @property {string} [ctaUrl] - Optional URL for the call-to-action button
+ * @property {string} [className] - Optional additional CSS classes to apply to the component
+ */
+export type QuickFactsProps = {
+  title: string
+  facts: FactItem[]
+  ctaText?: string
+  ctaUrl?: string
+  className?: string
+}
+
+/**
+ * QuickFacts Component
+ *
+ * Each fact consists of an icon, label, and value.
+ *
+ * @example
+ * ```tsx
+ * import { Clock, Euro, Hospital } from 'lucide-react'
+ *
+ * <QuickFacts
+ *   title="Quick Facts About Breast Reduction"
+ *   facts={[
+ *     { icon: Euro, label: "Price", value: "from 55,000 SEK" },
+ *     { icon: Clock, label: "Duration", value: "1.5–2 hours" },
+ *     { icon: Hospital, label: "Anesthesia", value: "General anesthesia" }
+ *   ]}
+ *   ctaText="BOOK CONSULTATION"
+ *   ctaUrl="/booking"
+ * />
+ * ```
+ */
+export const QuickFacts = ({
+  title,
+  facts,
+  ctaText,
+  ctaUrl = '#',
+  className = ''
+}: QuickFactsProps) => {
+  return (
+    <section
+      className={`mx-auto my-8 w-full max-w-3xl border border-gray-200 bg-white ${className}`}
+      aria-labelledby="quick-facts-title"
+    >
+      <H2
+        id="quick-facts-title"
+        className="!mb-0 border-b border-gray-100 p-4 text-2xl"
+      >
+        {title}
+      </H2>
+
+      <dl className="space-y-4 p-4">
+        {facts.map((fact) => {
+          const Icon = fact.icon
+          return (
+            <div key={fact.label} className="mb-3 flex items-start gap-2">
+              <Icon
+                className="text-green mt-0.5 h-5 w-5 flex-shrink-0"
+                aria-hidden="true"
+              />
+              <div className="flex flex-wrap items-baseline">
+                <dt className="mr-2">{fact.label}:</dt>
+                <dd className="font-light">
+                  {typeof fact.value === 'string' ? fact.value : fact.value}
+                </dd>
+              </div>
+            </div>
+          )
+        })}
+      </dl>
+
+      {ctaText && (
+        <div className="p-4 pt-2">
+          <A
+            inverted
+            small
+            href={ctaUrl}
+            buttonStyle
+            className="inline-block rounded-md"
+          >
+            {ctaText}
+          </A>
+        </div>
+      )}
+    </section>
+  )
+}


### PR DESCRIPTION
This pull request introduces a new `QuickFacts` component and integrates it into the `Brostforstoring` page to enhance the presentation of key information.

### New Component Addition:
* **`QuickFacts` Component**: A reusable component for displaying quick facts with icons, labels, and values. Includes optional call-to-action (CTA) functionality. This component is designed to be flexible and visually appealing.
