### PR TITLE
fix: ensure footer state resets on route change

### DIFF
--- a/src/app/components/surfaces/HeaderWithFooter.tsx
+++ b/src/app/components/surfaces/HeaderWithFooter.tsx
@@ -32,7 +32,7 @@ export const HeaderWithFooter = () => {
 
   // Recalculate on route change to reset footer state on short pages
   useEffect(() => {
-    const pageHeight = document.body.scrollHeight
+    const pageHeight = document.documentElement.scrollHeight
     const isScrollable = pageHeight > window.innerHeight
     const scrollPosition = window.scrollY + window.innerHeight
     setIsAtBottom(isScrollable && scrollPosition >= pageHeight)

--- a/src/app/components/surfaces/HeaderWithFooter.tsx
+++ b/src/app/components/surfaces/HeaderWithFooter.tsx
@@ -18,7 +18,7 @@ export const HeaderWithFooter = () => {
   useEffect(() => {
     const handleScroll = () => {
       const scrollPosition = window.scrollY + window.innerHeight
-      const pageHeight = document.body.scrollHeight
+      const pageHeight = document.documentElement.scrollHeight
       const isScrollable = pageHeight > window.innerHeight
 
       // Expand only when scrollable and scrolled to bottom

--- a/src/app/components/surfaces/HeaderWithFooter.tsx
+++ b/src/app/components/surfaces/HeaderWithFooter.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useTranslations } from 'next-intl'
+import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
 import { Button } from '../inputs/Button'
@@ -10,6 +11,7 @@ import { SocialMediaLinks } from './SocialMediaLinks'
 
 export const HeaderWithFooter = () => {
   const t = useTranslations()
+  const pathname = usePathname()
   const [isAtBottom, setIsAtBottom] = useState(false)
 
   // Check if the user has scrolled to the bottom of the page
@@ -17,14 +19,24 @@ export const HeaderWithFooter = () => {
     const handleScroll = () => {
       const scrollPosition = window.scrollY + window.innerHeight
       const pageHeight = document.body.scrollHeight
+      const isScrollable = pageHeight > window.innerHeight
 
-      // Expand when scrolled to the bottom, shrink when scrolling up
-      setIsAtBottom(scrollPosition >= pageHeight)
+      // Expand only when scrollable and scrolled to bottom
+      setIsAtBottom(isScrollable && scrollPosition >= pageHeight)
     }
 
     window.addEventListener('scroll', handleScroll)
+    handleScroll() // initialize on mount
     return () => window.removeEventListener('scroll', handleScroll)
   }, [])
+
+  // Recalculate on route change to reset footer state on short pages
+  useEffect(() => {
+    const pageHeight = document.body.scrollHeight
+    const isScrollable = pageHeight > window.innerHeight
+    const scrollPosition = window.scrollY + window.innerHeight
+    setIsAtBottom(isScrollable && scrollPosition >= pageHeight)
+  }, [pathname])
 
   return (
     <header

--- a/src/app/components/surfaces/HeaderWithFooter.tsx
+++ b/src/app/components/surfaces/HeaderWithFooter.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useTranslations } from 'next-intl'
 import { usePathname } from 'next/navigation'
+import { useTranslations } from 'next-intl'
 import { useEffect, useState } from 'react'
 
 import { Button } from '../inputs/Button'


### PR DESCRIPTION
This pull request updates the `HeaderWithFooter` component to improve its behavior when detecting scroll position and reacting to route changes. The key changes include refining the logic for determining if the user has scrolled to the bottom of the page and ensuring the footer state resets appropriately when navigating between routes.

### Enhancements to scroll detection:

* Updated the logic in the `handleScroll` function to check if the page is scrollable before determining whether the user has scrolled to the bottom. This prevents unnecessary state updates on non-scrollable pages.
* Added an immediate invocation of `handleScroll` when the component mounts to initialize the footer state correctly.

### Route change handling:

* Introduced a dependency on `pathname` from `next/navigation` to monitor route changes. Added a `useEffect` hook to recalculate the footer state whenever the route changes, ensuring the footer behaves correctly on pages with varying content heights. [[1]](diffhunk://#diff-47a66cdde1007a1b21d52aba272bb19c51a5b8e7c56875bd616504f339d7a94aR4) [[2]](diffhunk://#diff-47a66cdde1007a1b21d52aba272bb19c51a5b8e7c56875bd616504f339d7a94aR14-R40)