### PR TITLE
fix: update pre-commit script to use bash and npx for lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 . "$(dirname -- "$0")/_/husky.sh"
 
-pnpm lint-staged
+npx lint-staged


### PR DESCRIPTION
This pull request includes a small update to the `.husky/pre-commit` file, changing the shell interpreter and the command used for lint-staged execution.

* [`.husky/pre-commit`](diffhunk://#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dL1-R4): Updated the shebang from `sh` to `bash` and replaced `pnpm lint-staged` with `npx lint-staged`.