### PR TITLE
docs: add semantic release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ A high-level overview of the folder structure:
 └── tsconfig.json         # TypeScript configuration
 ```
 
+## Release Process
+
+This project uses [Semantic Release](https://semantic-release.gitbook.io/) for automated versioning and publishing:
+
+- **Production releases**: Merges to `main` branch trigger production releases
+- **Beta releases**: Merges to `develop` branch trigger pre-release versions
+- **Commit format**: Follow [Conventional Commits](https://conventionalcommits.org/) for proper versioning
+
 ## Technologies Used
 
 - [Next.js 14](https://nextjs.org/) - React framework for building web applications.
@@ -78,3 +86,4 @@ A high-level overview of the folder structure:
 - [Tailwind CSS](https://tailwindcss.com/) - Utility-first CSS framework.
 - [ESLint](https://eslint.org/) - Linting tool for JavaScript/TypeScript.
 - [Prettier](https://prettier.io/) - Code formatting tool.
+- [Semantic Release](https://semantic-release.gitbook.io/) - Automated versioning and package publishing.


### PR DESCRIPTION
This PR adds documentation about the semantic release process to the README.

## Changes
- Added a new 'Release Process' section explaining production and beta release branches
- Documented conventional commit format requirements
- Added semantic-release to the technologies used list

## Why
This documentation will help developers understand the automated release workflow and commit conventions, making it easier to trigger releases properly.

## Release Impact
- **Type**: Documentation change (`docs:`)
- **Version Impact**: Patch release (documentation changes don't affect functionality)
- **Target**: This will trigger a beta release when merged to develop

## Notes
Merging this PR to develop will trigger an automated beta release via semantic-release.