### PR TITLE
fix: update CSP to allow additional Google and Facebook domains

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -41,13 +41,17 @@ export function middleware(request: NextRequest) {
       https://www.googletagmanager.com
       https://www.google.com
       https://*.google.com
+      https://www.google.se
+      https://*.google.se
       https://www.facebook.com
       https://*.facebook.com
       https://connect.facebook.net
       https://stats.g.doubleclick.net
       https://*.doubleclick.net
       https://pagead2.googlesyndication.com
+      https://*.googlesyndication.com
       https://www.googleadservices.com
+      https://*.googleadservices.com
       https://cookie-script.com
       https://*.cookie-script.com;
 
@@ -57,6 +61,8 @@ export function middleware(request: NextRequest) {
       'self'
       https://www.google.com
       https://*.google.com
+      https://www.google.se
+  +   https://*.google.se
       https://www.google-analytics.com
       https://*.google-analytics.com
       https://analytics.google.com
@@ -67,7 +73,9 @@ export function middleware(request: NextRequest) {
       https://*.doubleclick.net
       https://td.doubleclick.net
       https://pagead2.googlesyndication.com
+      https://*.googlesyndication.com
       https://www.googleadservices.com
+      https://*.googleadservices.com
       https://tagassistant.google.com
       https://graph.facebook.com
       https://www.facebook.com


### PR DESCRIPTION
This pull request updates the Content Security Policy (CSP) configuration in the `middleware` function to expand the list of allowed sources for scripts and resources, primarily to improve compatibility with Google and advertising services. The changes add support for additional subdomains and country-specific domains, which helps ensure that third-party integrations continue to work as expected.

**Content Security Policy updates:**

* Added `https://www.google.se` and `https://*.google.se` to the allowed sources for Google-related resources, supporting Swedish Google domains. [[1]](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0R44-R54) [[2]](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0R64-R65)
* Included `https://*.googlesyndication.com` and `https://*.googleadservices.com` to support additional advertising scripts and resources from Google. [[1]](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0R44-R54) [[2]](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0R76-R78)