### PR TITLE
Release/v1.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.17.3-beta.1](https://github.com/dahliakliniken/drgribbe/compare/v1.17.2...v1.17.3-beta.1) (2025-08-19)
+
+
+### Bug Fixes
+
+* update CSP to allow Google Tag Manager and Google Fonts ([42154c9](https://github.com/dahliakliniken/drgribbe/commit/42154c913ebf3ddf9ac0ab9ce79e7c403d541666))
+
 ## [1.17.2](https://github.com/dahliakliniken/drgribbe/compare/v1.17.1...v1.17.2) (2025-08-19)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drgribbe",
-  "version": "1.17.2",
+  "version": "1.17.3-beta.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -30,6 +30,8 @@ export function middleware(request: NextRequest) {
     style-src
       'self'
       'unsafe-inline'
+      https://www.googletagmanager.com
+      https://fonts.googleapis.com
       https://cookie-script.com
       https://*.cookie-script.com;
 
@@ -39,6 +41,7 @@ export function middleware(request: NextRequest) {
       blob:
       https://www.google-analytics.com
       https://www.googletagmanager.com
+      https://fonts.gstatic.com
       https://www.google.com
       https://*.google.com
       https://www.google.se
@@ -55,7 +58,7 @@ export function middleware(request: NextRequest) {
       https://cookie-script.com
       https://*.cookie-script.com;
 
-    font-src 'self';
+    font-src 'self' https://fonts.gstatic.com;
 
     connect-src
       'self'


### PR DESCRIPTION
This pull request updates the Content Security Policy (CSP) to support Google Tag Manager and Google Fonts, addressing issues with third-party integrations and font loading. It also bumps the package version to `1.17.3-beta.1` and documents the bug fix in the changelog.

**CSP updates for third-party integrations:**

* Allowed `https://www.googletagmanager.com` and `https://fonts.googleapis.com` in the `style-src` directive in `src/middleware.ts` to enable Google Tag Manager and Google Fonts styles.
* Allowed `https://fonts.gstatic.com` in both the `media-src` and `font-src` directives in `src/middleware.ts` to support font loading from Google Fonts. [[1]](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0R44) [[2]](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0L58-R61)

**Versioning and documentation:**

* Updated `package.json` to version `1.17.3-beta.1`.
* Added a changelog entry for version `1.17.3-beta.1`, documenting the CSP update as a bug fix.