### PR TITLE
feat: add thank you page

### DIFF
--- a/src/app/components/layout/SpaceContainer.tsx
+++ b/src/app/components/layout/SpaceContainer.tsx
@@ -2,7 +2,6 @@ import classNames from 'classnames'
 
 type SpaceContainerProps = {
   as?: 'section' | 'article' | 'div'
-  centered?: boolean
   noPadding?: boolean
   spaceVertically?: boolean
   spaceTop?: boolean

--- a/src/app/components/surfaces/Card.tsx
+++ b/src/app/components/surfaces/Card.tsx
@@ -60,8 +60,8 @@ export const Card = ({
         bgColor,
         'relative h-full before:absolute before:top-0 before:left-0 before:h-full before:w-full',
         {
-          'before:bg-card-pattern-light before:opacity-40': isWhite,
-          'before:bg-card-pattern before:opacity-40': isBeige,
+          'before:bg-card-pattern-light before:opacity-0': isWhite,
+          'before:bg-card-pattern before:opacity-30': isBeige,
           'before:bg-card-pattern before:opacity-5': !isWhite && !isBeige
         }
       )}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: '/private/'
+        disallow: ['/private/', '/tack']
       }
     ],
     sitemap: process.env.SITE_URL || 'https://www.dahliakliniken.se'

--- a/src/app/tack/StepsSection.tsx
+++ b/src/app/tack/StepsSection.tsx
@@ -1,0 +1,72 @@
+import type { LucideIcon } from 'lucide-react'
+import { ClipboardCheck, Info, Mail } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
+import { Card } from '@/app/components/surfaces/Card'
+import { H2 } from '@/app/components/typography/H2'
+import { H3 } from '@/app/components/typography/H3'
+import { P } from '@/app/components/typography/P'
+import { BgColors } from '@/app/types'
+
+type Step = {
+  title: string
+  description: string
+  icon: LucideIcon
+}
+
+export function StepsSection() {
+  const t = useTranslations('tack.steps')
+
+  const steps: Step[] = [
+    {
+      title: t('step1.title'),
+      description: t('step1.description'),
+      icon: Mail
+    },
+    {
+      title: t('step2.title'),
+      description: t('step2.description'),
+      icon: Info
+    },
+    {
+      title: t('step3.title'),
+      description: t('step3.description'),
+      icon: ClipboardCheck
+    }
+  ]
+
+  return (
+    <Card
+      bgColor={BgColors.Beige}
+      className="before:bg-[-100%_20%]"
+      content={
+          <div className="relative mx-auto w-full max-w-6xl px-5 sm:px-8 lg:px-10">
+            <div className="mx-auto max-w-3xl text-center">
+              <H2 id="what-happens-next-title">{t('title')}</H2>
+            </div>
+
+            <div className="mt-10 grid gap-8 md:grid-cols-3 md:gap-0">
+              {steps.map((step, idx) => (
+                <article
+                  key={step.title}
+                  className={`px-4 text-center md:px-10 ${idx > 0 ? 'md:border-gold md:border-l' : ''}`}
+                >
+                  <div className="mb-6 flex justify-center">
+                    <div className="text-gold inline-flex size-16 items-center justify-center">
+                      <step.icon
+                        aria-hidden="true"
+                        className="size-11"
+                        strokeWidth={1.4}
+                      />
+                    </div>
+                  </div>
+                  <H3 className="font-medium">{step.title}</H3>
+                  <P>{step.description}</P>
+                </article>
+              ))}
+            </div>
+          </div>
+      }
+    />
+  )
+}

--- a/src/app/tack/Tack.tsx
+++ b/src/app/tack/Tack.tsx
@@ -1,0 +1,37 @@
+import { Check } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
+import { H2 } from '@/app/components/typography/H2'
+import { P } from '@/app/components/typography/P'
+import { StepsSection } from '@/app/tack/StepsSection'
+import { SpaceContainer } from '@/components/layout/SpaceContainer'
+import { H1 } from '@/components/typography/H1'
+
+export const Tack = () => {
+  const t = useTranslations('tack')
+
+  return (
+    <>
+      <SpaceContainer spaceTop>
+        <div className="flex flex-col items-center">
+          <div className="bg-green/10 mb-8 flex h-20 w-20 items-center justify-center rounded-full">
+            <div className="bg-green flex h-14 w-14 items-center justify-center rounded-full">
+              <Check className="h-7 w-7 text-white" strokeWidth={2.5} />
+            </div>
+          </div>
+          <H1>{t('title')}</H1>
+          <P>{t('intro')}</P>
+          <section className="my-6 flex justify-center px-6 pb-16">
+            <div className="border-gold bg-beige/40 w-full max-w-lg rounded-2xl border p-8 text-center shadow-lg">
+              <H2>{t('confirmation.title')}</H2>
+
+              <P>{t('confirmation.text1')}</P>
+              <P>{t('confirmation.text2')}</P>
+            </div>
+          </section>
+        </div>
+      </SpaceContainer>
+      <StepsSection />
+    </>
+  )
+}

--- a/src/app/tack/page.tsx
+++ b/src/app/tack/page.tsx
@@ -1,0 +1,29 @@
+import { Metadata } from 'next'
+
+import { Tack } from '@/app/tack/Tack'
+
+export const metadata: Metadata = {
+  title: 'Tack för din bokning - Dahliakliniken',
+  description:
+    'I alla priser ingår allt såsom narkos, implantat, övernattning och återbesök.',
+  robots: {
+    index: false,
+    follow: false
+  },
+  openGraph: {
+    title: 'Tack för din bokning - Dahliakliniken',
+    description:
+      'I alla priser ingår allt såsom narkos, implantat, övernattning och återbesök.'
+  },
+  twitter: {
+    title: 'Tack för din bokning - Dahliakliniken',
+    description:
+      'I alla priser ingår allt såsom narkos, implantat, övernattning och återbesök.'
+  }
+}
+
+function TackPage() {
+  return <Tack />
+}
+
+export default TackPage

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -2,9 +2,14 @@ import { getRequestConfig } from 'next-intl/server'
 
 export default getRequestConfig(async () => {
   const locale = 'sv'
+  const baseMessages = (await import(`../messages/${locale}.json`)).default
+  const tackMessages = (await import(`../messages/tack/${locale}.json`)).default
 
   return {
     locale,
-    messages: (await import(`../messages/${locale}.json`)).default
+    messages: {
+      ...baseMessages,
+      tack: tackMessages
+    }
   }
 })

--- a/src/messages/tack/sv.json
+++ b/src/messages/tack/sv.json
@@ -1,0 +1,24 @@
+{
+  "title": "Tack för din bokning",
+  "intro": "Vi ser fram emot att välkomna dig till vår klinik i Stockholm.",
+  "confirmation": {
+    "title": "Bekräftelse skickad",
+    "text1": "Du får en bekräftelse via e-post inom kort. Om du inte ser den inom några minuter, kontrollera din skräppost.",
+    "text2": "Inför ditt besök är du varmt välkommen att kontakta oss om du har frågor eller funderingar."
+  },
+  "steps": {
+    "title": "Vad händer nu?",
+    "step1": {
+      "title": "Bekräftelse via e-post",
+      "description": "Du får en bekräftelse via e-post inom kort. Om du inte ser den, kontrollera din skräppost."
+    },
+    "step2": {
+      "title": "Praktisk information",
+      "description": "All information om tid, plats och eventuella förberedelser finns i din bekräftelse."
+    },
+    "step3": {
+      "title": "Behöver du ändra något?",
+      "description": "Vill du boka om eller har frågor är du varmt välkommen att kontakta oss."
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
This pull request introduces a new localized "Thank You" (Tack) page flow for booking confirmations, including internationalization support, new UI components, and SEO/robots adjustments. The main changes are the addition of the new page and its supporting components, updates to translation loading, and minor UI and SEO tweaks.

**New "Thank You" Page and Components:**

- Added a new `Tack` page at `/tack`, including the main `Tack` component and a `StepsSection` component, both using localized Swedish content and providing users with booking confirmation details and next steps. 
- Created a Swedish translation file for the new page, containing all required strings for the confirmation and steps. 

**Internationalization Improvements:**

- Updated the i18n request configuration to merge base and "tack" page translations for proper namespacing and loading. 

**SEO and Robots Adjustments:**

- Updated the robots.txt configuration to disallow crawling of both `/private/` and the new `/tack` route. 
- Set the `/tack` page metadata to prevent indexing and following by search engines. 